### PR TITLE
chore: release v0.1.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1066,7 +1066,7 @@ dependencies = [
 
 [[package]]
 name = "noaa_weather_client"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "quick-xml",
  "reqwest",

--- a/noaa_weather_client/CHANGELOG.md
+++ b/noaa_weather_client/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/seferino-fernandez/noaa_weather/compare/noaa_weather_client-v0.1.2...noaa_weather_client-v0.1.3) - 2025-06-21
+
+### Added
+
+- Use rustls for linux and added Homebrew docs
+
+### Other
+
+- Revert versions to 0.1.2 to re-enable release-plz
+
 ## [0.1.0](https://github.com/seferino-fernandez/noaa_weather/releases/tag/noaa_weather_client-v0.1.0) - 2025-06-19
 
 ### Added

--- a/noaa_weather_client/Cargo.toml
+++ b/noaa_weather_client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noaa_weather_client"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 description = "A client library for the NOAA weather.gov API"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `noaa_weather_client`: 0.1.2 -> 0.1.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.3](https://github.com/seferino-fernandez/noaa_weather/compare/noaa_weather_client-v0.1.2...noaa_weather_client-v0.1.3) - 2025-06-21

### Added

- Use rustls for linux and added Homebrew docs

### Other

- Revert versions to 0.1.2 to re-enable release-plz
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).