### PR TITLE
chore: release v0.1.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1051,7 +1051,7 @@ dependencies = [
 
 [[package]]
 name = "noaa_weather_cli"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1066,7 +1066,7 @@ dependencies = [
 
 [[package]]
 name = "noaa_weather_client"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "quick-xml",
  "reqwest",

--- a/noaa_weather_cli/Cargo.toml
+++ b/noaa_weather_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noaa_weather_cli"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2024"
 description = "A CLI for the NOAA Weather API client."
 publish = false

--- a/noaa_weather_client/CHANGELOG.md
+++ b/noaa_weather_client/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4](https://github.com/seferino-fernandez/noaa_weather/compare/noaa_weather_client-v0.1.3...noaa_weather_client-v0.1.4) - 2025-06-21
+
+### Fixed
+
+- *(client)* Cleared up clippy lint suggestions
+
 ## [0.1.3](https://github.com/seferino-fernandez/noaa_weather/compare/noaa_weather_client-v0.1.2...noaa_weather_client-v0.1.3) - 2025-06-21
 
 ### Added

--- a/noaa_weather_client/Cargo.toml
+++ b/noaa_weather_client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noaa_weather_client"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2024"
 description = "A client library for the NOAA weather.gov API"
 license = "MIT"

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,42 +1,18 @@
-# This is the global configuration, applied to all packages by default.
 [workspace]
-# The `release` command will only release packages when the merge commit of a
-# release-plz PR is detected. This provides a chance to review versions and
-# changelogs before publishing.
 release_always = false
-
-# When creating the release PR, run `cargo update` to refresh the Cargo.lock file.
 dependencies_update = true
 
-# The release PR will be created as a draft, allowing for manual review and
-# checks to pass before it's marked as "Ready for review".
 pr_draft = true
-
-# Add a "release" label to the PR created by release-plz for better tracking.
 pr_labels = ["release"]
 
-# --- Package-specific configurations ---
-# The double square brackets define a TOML table array.
-
-# Configuration for the client library.
 [[package]]
 name = "noaa_weather_client"
-# This package will be published to crates.io. `publish = true` is the default,
-# but it is specified here for clarity.
 publish = true
-# This package will have a GitHub Release with a changelog.
-# `git_release_enable = true` is also the default.
 git_release_enable = true
-# Keep this package's version in sync with other packages in the same group.
 version_group = "noaa_weather"
 
-# Configuration for the CLI application.
 [[package]]
 name = "noaa_weather_cli"
-# Do NOT publish the CLI binary crate to crates.io.
 publish = false
-# DO create a GitHub Release for the CLI. The `cd.yml` workflow will
-# attach the compiled binary assets to this release.
 git_release_enable = true
-# Keep this package's version in sync with other packages in the same group.
 version_group = "noaa_weather"


### PR DESCRIPTION



## 🤖 New release

* `noaa_weather_client`: 0.1.3 -> 0.1.4 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.4](https://github.com/seferino-fernandez/noaa_weather/compare/noaa_weather_client-v0.1.3...noaa_weather_client-v0.1.4) - 2025-06-21

### Fixed

- *(client)* Cleared up clippy lint suggestions
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).