### PR TITLE
chore: release v0.1.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1051,7 +1051,7 @@ dependencies = [
 
 [[package]]
 name = "noaa_weather_cli"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1066,7 +1066,7 @@ dependencies = [
 
 [[package]]
 name = "noaa_weather_client"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "quick-xml",
  "reqwest",

--- a/noaa_weather_cli/Cargo.toml
+++ b/noaa_weather_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noaa_weather_cli"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2024"
 description = "A CLI for the NOAA Weather API client."
 publish = false

--- a/noaa_weather_client/CHANGELOG.md
+++ b/noaa_weather_client/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.5](https://github.com/seferino-fernandez/noaa_weather/compare/noaa_weather_client-v0.1.4...noaa_weather_client-v0.1.5)
+_21 June 2025_
+
+### Fixed
+
+* *(cli, client)* Clippy lints - removed single chars, and redundant clones, and more
+
 ## [0.1.4](https://github.com/seferino-fernandez/noaa_weather/compare/noaa_weather_client-v0.1.3...noaa_weather_client-v0.1.4) - 2025-06-21
 
 ### Fixed

--- a/noaa_weather_client/Cargo.toml
+++ b/noaa_weather_client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noaa_weather_client"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2024"
 description = "A client library for the NOAA weather.gov API"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `noaa_weather_client`: 0.1.4 -> 0.1.5 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.5](https://github.com/seferino-fernandez/noaa_weather/compare/noaa_weather_client-v0.1.4...noaa_weather_client-v0.1.5)

_21 June 2025_

### Fixed

* *(cli, client)* Clippy lints - removed single chars, and redundant clones, and more
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).