### PR TITLE
chore: release v1.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1161,7 +1161,7 @@ dependencies = [
 
 [[package]]
 name = "noaa_weather_cli"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1176,7 +1176,7 @@ dependencies = [
 
 [[package]]
 name = "noaa_weather_client"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "quick-xml",
  "reqwest",
@@ -2894,18 +2894,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.39"
+version = "0.8.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db6d35d663eadb6c932438e763b262fe1a70987f9ae936e60158176d710cae4a"
+checksum = "a789c6e490b576db9f7e6b6d661bcc9799f7c0ac8352f56ea20193b2681532e5"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.39"
+version = "0.8.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
+checksum = "f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/README.md
+++ b/README.md
@@ -52,14 +52,14 @@ or add to your `Cargo.toml` manually:
 
 ```toml
 [dependencies]
-noaa_weather_client = "1.0.0"
+noaa_weather_client = "1.1.0"
 ```
 
 To enable NOAA Weather Radio support:
 
 ```toml
 [dependencies]
-noaa_weather_client = { version = "1.0.0", features = ["radio"] }
+noaa_weather_client = { version = "1.1.0", features = ["radio"] }
 ```
 
 ## Documentation

--- a/noaa_weather_cli/Cargo.toml
+++ b/noaa_weather_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noaa_weather_cli"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2024"
 description = "A CLI for the NOAA Weather API client."
 publish = false

--- a/noaa_weather_client/CHANGELOG.md
+++ b/noaa_weather_client/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.0](https://github.com/seferino-fernandez/noaa_weather/compare/v0.1.8...v1.0.0)
+## [1.1.0](https://github.com/seferino-fernandez/noaa_weather/compare/v0.1.8...v1.1.0)
 
 _26 February 2026_
 

--- a/noaa_weather_client/Cargo.toml
+++ b/noaa_weather_client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noaa_weather_client"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2024"
 description = "A client library for the NOAA weather.gov API"
 license = "MIT"

--- a/noaa_weather_client/README.md
+++ b/noaa_weather_client/README.md
@@ -22,14 +22,14 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-noaa_weather_client = "1.0.0"
+noaa_weather_client = "1.1.0"
 ```
 
 To enable NOAA Weather Radio support (requires the `quick-xml` dependency):
 
 ```toml
 [dependencies]
-noaa_weather_client = { version = "1.0.0", features = ["radio"] }
+noaa_weather_client = { version = "1.1.0", features = ["radio"] }
 ```
 
 ### Running Examples


### PR DESCRIPTION



## 🤖 New release

* `noaa_weather_client`: 0.1.8 -> 1.1.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.1.0](https://github.com/seferino-fernandez/noaa_weather/compare/v0.1.8...v1.1.0)

_26 February 2026_

### Added

- Add radio broadcast API module behind 'radio' feature flag
- Add get_latest_product_by_type_and_location endpoint
- Add Feature-Flags header to zone stations endpoint
- Add Feature-Flags header to station endpoints and cursor to observations
- [**breaking**] Update gridpoints stations to use feature_flags instead of cursor
- [**breaking**] Change points API to use separate latitude/longitude parameters
- [**breaking**] Split GridpointForecast into Gridpoint12hForecast and GridpointHourlyForecast
- Add PointType, AstronomicalData, NoaaWeatherRadio models and Point fields
- Add pagination field to ObservationCollection models
- Add provider, subProvider, distance, bearing fields to ObservationStation
- Add scope, code, language, web, eventCode fields to Alert model
- Add PQE and PQW forecast office ID variants
- Add API key authentication support to Configuration

### Documented

- Updated documentation with the latest v3.6.0 changes

### Fixed

- Removed broken radio quick-xml tests
- Update basic_usage example for new points API latitude/longitude parameters

### Other

- Format, lint fixes, and extract X-Api-Key constant
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).